### PR TITLE
Fix exit status 137 when container stops.

### DIFF
--- a/php/7.3/fpm/Dockerfile
+++ b/php/7.3/fpm/Dockerfile
@@ -15,7 +15,7 @@ STOPSIGNAL SIGQUIT
 # PHP-FPM packages need a nudge to make them docker-friendly
 COPY overrides.conf /etc/php/7.3/fpm/pool.d/z-overrides.conf
 
-CMD ["/usr/sbin/php-fpm7.3", "-O" ]
+CMD ["/usr/sbin/php-fpm7.3", "-O", "-F" ]
 
 # Open up fcgi port
 EXPOSE 9000


### PR DESCRIPTION
Fix exit status 137, when docker-compose stop. Docker compose wait for 10 seconds to kill php-fpm process by SIGTERM 9.