### PR TITLE
Deprecate EOL PHP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Images are [built daily](https://ci.auronconsulting.co.uk/teams/main/pipelines/p
 * Daily builds are kept for PHP versions that have reached EOL but the base OS has not - the base OS still receives security updates, including the PHP runtime.
 * In general, do not use any unsupported images in a production environment, regardless of whether daily builds are still enabled
 * Old images are kept in docker hub in the interest of enabling legacy apps to run
+* Ondřej Surý is PHP's package maintainer in Debian. His Ubuntu PPA PPA allows us to have more up to date packages beyond those provided by the base image OS.
 
 | PHP version  | CLI image | FPM image | Source | Supported | Daily builds? |
 | ------------ | --------- |---------- |------- |----------- |-------------- |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Notes:
 * Old images are kept in docker hub in the interest of enabling legacy apps to run
 
 
-| PHP version  | CLI image | FPM image | Source | Supported / Daily builds? | Daily builds? |
+| PHP version  | CLI image | FPM image | Source | Supported | Daily builds? |
 | ------------ | --------- |---------- |------- |----------- |-------------- |
 | 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ✔ | ✔ |
 | 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✔ | ✔ |

--- a/README.md
+++ b/README.md
@@ -6,11 +6,24 @@ Repository of base images for [PHPDocker.io](http://phpdocker.io) generated envi
 All images are [built daily](https://ci.auronconsulting.co.uk/teams/main/pipelines/phpdocker-base-images) in order to fetch the latest base image changes as well as available php versions.
 
 ### Currently supported PHP versions:
- * PHP 7.2 (Ubuntu 18.04 + ondrej ppa)
- * PHP 7.3 (Ubuntu 18.04 + ondrej ppa)
- * PHP 7.4 (Ubuntu 20.04 + ondrej ppa)
+
+| PHP version | CLI image | FPM image | Source |
+| -------------------------------------------- |
+
+ * PHP 7.2: `phpdockerio/php72-cli` and `phpdockerio/php72-fpm` (Ubuntu 18.04 + ondrej ppa)
+ * PHP 7.3: `phpdockerio/php73-cli` and `phpdockerio/php73-fpm` (Ubuntu 18.04 + ondrej ppa)
+ * PHP 7.4: `phpdockerio/php74-cli` and `phpdockerio/php74-fpm` (Ubuntu 20.04 + ondrej ppa)
+ * PHP 7.4 + swoole: `phpdockerio/php74-swoole` (Ubuntu 20.04 + ondrej ppa + Swoole built from source)
 
 ### Legacy versions (reached [PHP end of life](https://www.php.net/supported-versions.php)):
+
+You should not use these images as they're well past their end of life. You can still pull them
+off docker hub, but we aren't building them any more. 
+
+These images still exist in docker hub, but we aren't building them periodically any more.
+
+*DO NOT USE*
+
  * PHP 5.6 (debian jessie)
  * PHP 7.0 (Ubuntu 16.04)
  * PHP 7.1 (Ubuntu 16.04 + ondrej ppa)

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Images without daily builds are still available in docker hub in the interest of
 
 | PHP version  | CLI image | FPM image | Source | Supported? | Daily builds? |
 | ------------ | --------- |---------- |------- |----------- |-------------- |
-| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ❌ | ✅ |
-| 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✅ | ✅ |
-| 7.3 | `phpdockerio/php73-cli` | `phpdockerio/php73-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✅ | ✅ |
-| 7.2 | `phpdockerio/php72-cli` | `phpdockerio/php72-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✅ | ✅ |
-| 7.1 | `phpdockerio/php71-cli` | `phpdockerio/php71-cli` | Ubuntu 16.04 + Ondřej Surý ppa | ❌ | ✅ |
-| 7.0 | `phpdockerio/php70-cli` | `phpdockerio/php70-cli` | Ubuntu 16.04 | ❌ | ✅ |
+| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ❌ | ✔ |
+| 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✔ | ✔ |
+| 7.3 | `phpdockerio/php73-cli` | `phpdockerio/php73-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ | ✔ |
+| 7.2 | `phpdockerio/php72-cli` | `phpdockerio/php72-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ | ✔ |
+| 7.1 | `phpdockerio/php71-cli` | `phpdockerio/php71-cli` | Ubuntu 16.04 + Ondřej Surý ppa | ❌ | ✔ |
+| 7.0 | `phpdockerio/php70-cli` | `phpdockerio/php70-cli` | Ubuntu 16.04 | ❌ | ✔ |
 | 5.6 | `phpdockerio/php56-cli` | `phpdockerio/php56-cli` | Debian Jessie | ❌ | ❌ |

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Notes:
 * Old images are kept in docker hub in the interest of enabling legacy apps to run
 
 
-| PHP version  | CLI image | FPM image | Source | Supported / Daily builds? |
-| ------------ | --------- |---------- |------- |-------------------------- |
-| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ✔ / ✔ |
-| 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✔ / ✔ |
-| 7.3 | `phpdockerio/php73-cli` | `phpdockerio/php73-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ / ✔ |
-| 7.2 | `phpdockerio/php72-cli` | `phpdockerio/php72-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ / ✔ |
-| 7.1 | `phpdockerio/php71-cli` | `phpdockerio/php71-cli` | Ubuntu 16.04 + Ondřej Surý ppa | ❌ / ✔ |
-| 7.0 | `phpdockerio/php70-cli` | `phpdockerio/php70-cli` | Ubuntu 16.04 | ❌ / ✔ |
-| 5.6 | `phpdockerio/php56-cli` | `phpdockerio/php56-cli` | Debian Jessie | ❌ / ❌ |
+| PHP version  | CLI image | FPM image | Source | Supported / Daily builds? | Daily builds? |
+| ------------ | --------- |---------- |------- |----------- |-------------- |
+| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ✔ | ✔ |
+| 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✔ | ✔ |
+| 7.3 | `phpdockerio/php73-cli` | `phpdockerio/php73-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ | ✔ |
+| 7.2 | `phpdockerio/php72-cli` | `phpdockerio/php72-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ | ✔ |
+| 7.1 | `phpdockerio/php71-cli` | `phpdockerio/php71-cli` | Ubuntu 16.04 + Ondřej Surý ppa | ❌ | ✔ |
+| 7.0 | `phpdockerio/php70-cli` | `phpdockerio/php70-cli` | Ubuntu 16.04 | ❌ | ✔ |
+| 5.6 | `phpdockerio/php56-cli` | `phpdockerio/php56-cli` | Debian Jessie | ❌ | ❌ |

--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@ Images are [built daily](https://ci.auronconsulting.co.uk/teams/main/pipelines/p
 
 ### Available images:
 
-Notes:
+**Notes:**
 
 * Unsupported versions are past PHP EOL (End of Life)
 * Daily builds are turned off for versions that run on an OS base that's also EOL (for instance, Debian Jessie)
 * Daily builds are kept for PHP versions that have reached EOL but the base OS has not - the base OS still receives security updates, including the PHP runtime.
 * In general, do not use any unsupported images in a production environment, regardless of whether daily builds are still enabled
 * Old images are kept in docker hub in the interest of enabling legacy apps to run
-
 
 | PHP version  | CLI image | FPM image | Source | Supported | Daily builds? |
 | ------------ | --------- |---------- |------- |----------- |-------------- |

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ Images are [built daily](https://ci.auronconsulting.co.uk/teams/main/pipelines/p
 
 ### Available images:
 
-Please note, PHP <= 7.1 are now past EOL (End Of Life) and as such are unsupported.
+Notes:
 
-Images without daily builds are still available in docker hub in the interest of allowing legacy apps to be run, but these images should never be used in a production environment and you should consider upgrading to the latest available PHP version.
+* Unsupported versions are past PHP EOL (End of Life)
+* Daily builds are turned off for versions that run on an OS base that's also EOL (for instance, Debian Jessie)
+* Daily builds are kept for PHP versions that have reached EOL but the base OS has not - the base OS still receives security updates, including the PHP runtime.
+* In general, do not use any unsupported images in a production environment, regardless of whether daily builds are still enabled
+* Old images are kept in docker hub in the interest of enabling legacy apps to run
 
 
 | PHP version  | CLI image | FPM image | Source | Supported? | Daily builds? |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Notes:
 
 | PHP version  | CLI image | FPM image | Source | Supported? | Daily builds? |
 | ------------ | --------- |---------- |------- |----------- |-------------- |
-| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ❌ | ✔ |
+| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ✔ | ✔ |
 | 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✔ | ✔ |
 | 7.3 | `phpdockerio/php73-cli` | `phpdockerio/php73-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ | ✔ |
 | 7.2 | `phpdockerio/php72-cli` | `phpdockerio/php72-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ | ✔ |

--- a/README.md
+++ b/README.md
@@ -3,27 +3,21 @@ PHPDocker.io base images
 
 Repository of base images for [PHPDocker.io](http://phpdocker.io) generated environments.
 
-All images are [built daily](https://ci.auronconsulting.co.uk/teams/main/pipelines/phpdocker-base-images) in order to fetch the latest base image changes as well as available php versions.
+Images are [built daily](https://ci.auronconsulting.co.uk/teams/main/pipelines/phpdocker-base-images) in order to fetch the latest base image changes as well as available php versions.
 
-### Currently supported PHP versions:
+### Available images:
 
-| PHP version | CLI image | FPM image | Source |
-| -------------------------------------------- |
+Please note, PHP <= 7.1 are now past EOL (End Of Life) and as such are unsupported.
 
- * PHP 7.2: `phpdockerio/php72-cli` and `phpdockerio/php72-fpm` (Ubuntu 18.04 + ondrej ppa)
- * PHP 7.3: `phpdockerio/php73-cli` and `phpdockerio/php73-fpm` (Ubuntu 18.04 + ondrej ppa)
- * PHP 7.4: `phpdockerio/php74-cli` and `phpdockerio/php74-fpm` (Ubuntu 20.04 + ondrej ppa)
- * PHP 7.4 + swoole: `phpdockerio/php74-swoole` (Ubuntu 20.04 + ondrej ppa + Swoole built from source)
+Images without daily builds are still available in docker hub in the interest of allowing legacy apps to be run, but these images should never be used in a production environment and you should consider upgrading to the latest available PHP version.
 
-### Legacy versions (reached [PHP end of life](https://www.php.net/supported-versions.php)):
 
-You should not use these images as they're well past their end of life. You can still pull them
-off docker hub, but we aren't building them any more. 
-
-These images still exist in docker hub, but we aren't building them periodically any more.
-
-*DO NOT USE*
-
- * PHP 5.6 (debian jessie)
- * PHP 7.0 (Ubuntu 16.04)
- * PHP 7.1 (Ubuntu 16.04 + ondrej ppa)
+| PHP version  | CLI image | FPM image | Source | Supported? | Daily builds? |
+| ------------ | --------- |---------- |------- |----------- |-------------- |
+| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ❌ | ✅ |
+| 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✅ | ✅ |
+| 7.3 | `phpdockerio/php73-cli` | `phpdockerio/php73-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✅ | ✅ |
+| 7.2 | `phpdockerio/php72-cli` | `phpdockerio/php72-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✅ | ✅ |
+| 7.1 | `phpdockerio/php71-cli` | `phpdockerio/php71-cli` | Ubuntu 16.04 + Ondřej Surý ppa | ❌ | ✅ |
+| 7.0 | `phpdockerio/php70-cli` | `phpdockerio/php70-cli` | Ubuntu 16.04 | ❌ | ✅ |
+| 5.6 | `phpdockerio/php56-cli` | `phpdockerio/php56-cli` | Debian Jessie | ❌ | ❌ |

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Notes:
 * Old images are kept in docker hub in the interest of enabling legacy apps to run
 
 
-| PHP version  | CLI image | FPM image | Source | Supported? | Daily builds? |
-| ------------ | --------- |---------- |------- |----------- |-------------- |
-| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ✔ | ✔ |
-| 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✔ | ✔ |
-| 7.3 | `phpdockerio/php73-cli` | `phpdockerio/php73-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ | ✔ |
-| 7.2 | `phpdockerio/php72-cli` | `phpdockerio/php72-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ | ✔ |
-| 7.1 | `phpdockerio/php71-cli` | `phpdockerio/php71-cli` | Ubuntu 16.04 + Ondřej Surý ppa | ❌ | ✔ |
-| 7.0 | `phpdockerio/php70-cli` | `phpdockerio/php70-cli` | Ubuntu 16.04 | ❌ | ✔ |
-| 5.6 | `phpdockerio/php56-cli` | `phpdockerio/php56-cli` | Debian Jessie | ❌ | ❌ |
+| PHP version  | CLI image | FPM image | Source | Supported / Daily builds? |
+| ------------ | --------- |---------- |------- |-------------------------- |
+| 7.4 (swoole) | `phpdockerio/php74-swoole` | n/a | Swoole sources | ✔ / ✔ |
+| 7.4 | `phpdockerio/php74-cli` | `phpdockerio/php74-cli` | Ubuntu 20.04 + Ondřej Surý ppa | ✔ / ✔ |
+| 7.3 | `phpdockerio/php73-cli` | `phpdockerio/php73-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ / ✔ |
+| 7.2 | `phpdockerio/php72-cli` | `phpdockerio/php72-cli` | Ubuntu 18.04 + Ondřej Surý ppa | ✔ / ✔ |
+| 7.1 | `phpdockerio/php71-cli` | `phpdockerio/php71-cli` | Ubuntu 16.04 + Ondřej Surý ppa | ❌ / ✔ |
+| 7.0 | `phpdockerio/php70-cli` | `phpdockerio/php70-cli` | Ubuntu 16.04 | ❌ / ✔ |
+| 5.6 | `phpdockerio/php56-cli` | `phpdockerio/php56-cli` | Debian Jessie | ❌ / ❌ |

--- a/concourse.yaml
+++ b/concourse.yaml
@@ -34,22 +34,6 @@ resources:
     stop: 1:50 AM
 
 # Docker hub repositories
-- name: php56-cli
-  type: docker-image
-  source:
-    email: {{docker-hub-email}}
-    username: {{docker-hub-user}}
-    password: {{docker-hub-password}}
-    repository: phpdockerio/php56-cli
-
-- name: php56-fpm
-  type: docker-image
-  source:
-    email: {{docker-hub-email}}
-    username: {{docker-hub-user}}
-    password: {{docker-hub-password}}
-    repository: phpdockerio/php56-fpm
-
 - name: php7-cli
   type: docker-image
   source:
@@ -139,20 +123,6 @@ resources:
     repository: phpdockerio/php74-swoole
 
 jobs:
-- name: php 5.6
-  public: true
-  plan:
-  - get: base-images
-    trigger: true
-  - get: time-slot-1
-    trigger: true
-  - put: php56-cli
-    params:
-        build: base-images/php/5.6/cli
-  - put: php56-fpm
-    params:
-        build: base-images/php/5.6/fpm
-
 - name: php 7.0
   public: true
   plan:
@@ -172,7 +142,7 @@ jobs:
   plan:
   - get: base-images
     trigger: true
-  - get: time-slot-2
+  - get: time-slot-1
     trigger: true
   - put: php71-cli
     params:
@@ -200,7 +170,7 @@ jobs:
   plan:
   - get: base-images
     trigger: true
-  - get: time-slot-3
+  - get: time-slot-2
     trigger: true
   - put: php73-cli
     params:
@@ -222,6 +192,9 @@ jobs:
   - put: php74-fpm
     params:
         build: base-images/php/7.4/fpm
+  - put: php74-swoole
+    params:
+        build: base-images/php/7.4/swoole
 
 - name: php 7.4 swoole
   public: true

--- a/concourse.yaml
+++ b/concourse.yaml
@@ -195,14 +195,3 @@ jobs:
   - put: php74-swoole
     params:
         build: base-images/php/7.4/swoole
-
-- name: php 7.4 swoole
-  public: true
-  plan:
-  - get: base-images
-    trigger: true
-  - get: time-slot-4
-    trigger: true
-  - put: php74-swoole
-    params:
-      build: base-images/php/7.4/swoole

--- a/concourse.yaml
+++ b/concourse.yaml
@@ -27,12 +27,6 @@ resources:
     start: 12:50 AM
     stop: 1:10 AM
 
-- name: time-slot-4
-  type: time
-  source:
-    start: 1:15 AM
-    stop: 1:50 AM
-
 # Docker hub repositories
 - name: php7-cli
   type: docker-image


### PR DESCRIPTION
 * Stop building php 5.6
 * Tweak README to give a better view of what images are available and their build / supported status
 * Collapse `php74-swoole` build into the end of the php74 build"
