### PR TITLE
Disable installation of the system's NGINX packages to avoid confusion and issues, and document it

### DIFF
--- a/nginx-pagespeed/Dockerfile
+++ b/nginx-pagespeed/Dockerfile
@@ -112,6 +112,9 @@ COPY nginx.conf /etc/nginx/nginx.conf
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+# Disable installation of nginx packages on the system
+COPY apt-preferences-disable-nginx /etc/apt/preferences.d/disable-nginx
+
 EXPOSE 80
 
 STOPSIGNAL SIGQUIT

--- a/nginx-pagespeed/README.md
+++ b/nginx-pagespeed/README.md
@@ -1,10 +1,10 @@
-# PHPDocker.io - nginx with PageSpeed container image
+# PHPDocker.io - NGINX with PageSpeed container image
 
-This is a container image for the newest available mainline version of nginx and its PageSpeed module. This image is [built daily](https://ci.auronconsulting.co.uk/teams/main/pipelines/phpdocker-base-images/jobs/nginx-pagespeed) to ensure we always have the newest available versions for both.
+This is a container image for the newest available mainline version of NGINX and its PageSpeed module. This image is [built daily](https://ci.auronconsulting.co.uk/teams/main/pipelines/phpdocker-base-images/jobs/nginx-pagespeed) to ensure we always have the newest available versions for both.
 
 The official image [https://hub.docker.com/r/pagespeed/nginx-pagespeed](https://hub.docker.com/r/pagespeed/nginx-pagespeed) is abandoned and of course it runs a very old and unpatched version of both nginx, its base OS and the PageSpeed module itself.
 
-This image uses the official installer script to install it into Ubuntu Focal (debian as base results in fatter image sizes) then proceeds to compile nginx with PageSpeed support using the same flags Ubuntu Focal's own nginx uses. It peruses nginx's official image's entrypoint and base config.
+This image uses the official installer script to install it into Ubuntu Focal (debian as base results in fatter image sizes) then proceeds to compile NGINX with PageSpeed support using the same flags Ubuntu Focal's own NGINX uses. It peruses nginx's official image's entrypoint and base config.
 
 ## PageSpeed configuration
 
@@ -13,3 +13,9 @@ Documentation of PageSpeed specific config: [https://www.modpagespeed.com/doc/co
 ## Adding your own config to nginx
 
 Make sure you add your .conf files to `/etc/nginx/conf.d/`. They'll be automagically picked up.
+
+## System NGINX packages
+
+The version of NGINX on this image is compiled from the latest mainline sources. Therefore, all of the base OS packages available are incompatible with it and will cause issues if installed. Therefore, all of the system's apt packages for nginx have been disabled for installation - you won't be able to do `apt install nginx` for instance.
+
+NGINX has been compiled with all modules Ubuntu includes by default - see the [Dockerfile](Dockerfile) for the full list. Please open a PR or an issue if there's a module that you'd like to install that isn't there.

--- a/nginx-pagespeed/apt-preferences-disable-nginx
+++ b/nginx-pagespeed/apt-preferences-disable-nginx
@@ -1,0 +1,3 @@
+Package: *nginx*
+Pin: release *
+Pin-Priority: -1


### PR DESCRIPTION
Since we're compiling nginx from sources, Ubuntu's (or debian's if we ever switch the base OS) nginx packages are all incompatible. 

This adds an apt policy to disallow installing any packages with `nginx` on the name.