### PR TITLE
Migrate php 8.1 image to Ubuntu Jammy

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
 
 | PHP version  | CLI image                    | FPM image                 | Source                         | Supported | Daily builds? |
 | ------------ | ---------------------------- | ------------------------- | ------------------------------ | --------- | ------------- |
-| 8.1          | `phpdockerio/php:8.1-cli`    | `phpdockerio/php:8.1-fpm` | Ubuntu 20.04 + Ondřej Surý ppa | ✔         | ✔             |
+| 8.1          | `phpdockerio/php:8.1-cli`    | `phpdockerio/php:8.1-fpm` | Ubuntu 22.04 + Ondřej Surý ppa | ✔         | ✔             |
 | 8.0          | `phpdockerio/php:8.0-cli`    | `phpdockerio/php:8.0-fpm` | Ubuntu 20.04 + Ondřej Surý ppa | ✔         | ✔             |
 | 7.4          | `phpdockerio/php:7.4-cli`    | `phpdockerio/php:7.4-fpm` | Ubuntu 20.04 + Ondřej Surý ppa | ✔         | ✔             |
 | 7.3          | `phpdockerio/php73-cli`      | `phpdockerio/php73-cli`   | Ubuntu 18.04 + Ondřej Surý ppa | ❌         | ✔             |

--- a/php/8.0/README.md
+++ b/php/8.0/README.md
@@ -37,5 +37,5 @@ $http->start();
 Second, run the container:
 
 ```bash
-docker run --rm -t -p 8101:8101 -v $(pwd):/app phpdockerio/php74-swoole php /app/index.php
+docker run --rm -t -p 8101:8101 -v $(pwd):/app phpdockerio/php80-swoole php /app/index.php
 ```

--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -2,7 +2,7 @@
 # PHPDocker.io PHP 8.1 / CLI and FPM image #
 ############################################
 
-FROM ubuntu:focal AS cli
+FROM ubuntu:jammy AS cli
 
 # Fixes some weird terminal issues such as broken clear / CTRL+L
 ENV TERM=linux

--- a/php/8.1/README.md
+++ b/php/8.1/README.md
@@ -1,41 +1,11 @@
-# PHPDocker.io - PHP 8.0 / CLI, FPM and Swoole container images
+# PHPDocker.io - PHP 8.1 / CLI, FPM and Swoole container images
 
-Ubuntu 20.04 PHP 8.0 CLI and FPM container images for [PHPDocker.io](http://phpdocker.io) projects. Packages are provided by [Ondřej Surý](https://deb.sury.org/).
+Ubuntu 22.04 PHP 8.1 CLI and FPM container images for [PHPDocker.io](http://phpdocker.io) projects. Packages are provided by [Ondřej Surý](https://deb.sury.org/).
 
-Far smaller in size than PHP's official container. No need to compile any extensions: simply run `apt-get install php8.0-EXTENSION_NAME` as part of your Dockerfile
+Far smaller in size than PHP's official container. No need to compile any extensions: simply run `apt-get install php8.1-EXTENSION_NAME` as part of your Dockerfile
 
 *Note on logging:* configure your application to stream logs into `php://stdout`. That's it.
 
 ## About swoole
 
 Swoole version is not configurable. We always provide the latest available via Ondrej's PPA to this version of PHP.
-
-### Usage
-
-First, configure your swoole front controller, take note of the port you're starting the server on. For instance:
-
-```php
-<?php
-/**
- * /app/index.php
- */
-
-$http = new swoole_http_server("0.0.0.0", 8101);
-
-$http->on("start", function ($server) {
-    echo "Swoole http server is started at http://127.0.0.1:8101\n";
-});
-
-$http->on("request", function ($request, $response) {
-    $response->header("Content-Type", "text/plain");
-    $response->end("Hello World\n");
-});
-
-$http->start();
-```
-
-Second, run the container:
-
-```bash
-docker run --rm -t -p 8101:8101 -v $(pwd):/app phpdockerio/php74-swoole php /app/index.php
-```


### PR DESCRIPTION
Now that's been out for a couple of months and has received enough updates, tweak the 8.1 container to run Ubuntu 22.04 Jammy.

Also fix some container README's copypasta issues